### PR TITLE
Fix: Update ChromeDriverManager to use the latest stable version

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def create_driver(headless=False):
         opts.add_argument("--headless=new")
         opts.add_argument("--window-size=1920,1080")
 
-    service = Service(ChromeDriverManager().install())
+    service = Service(ChromeDriverManager(version='latest').install())
     driver = webdriver.Chrome(service=service, options=opts)
 
     if not headless:


### PR DESCRIPTION
This change updates the `ChromeDriverManager` to install the latest stable version of ChromeDriver, which should resolve the issue with the current version not being supported.
---
*Automated by [GitPilot](https://github.com/bobbycalls/gitpilot) — your friendly AI maintainer*